### PR TITLE
Enable skipLibCheck

### DIFF
--- a/openfin-build-issue/tsconfig.json
+++ b/openfin-build-issue/tsconfig.json
@@ -19,6 +19,7 @@
     "target": "ES2022",
     "module": "ES2022",
     "useDefineForClassFields": false,
+    "skipLibCheck": true,
     "lib": [
       "ES2022",
       "dom"


### PR DESCRIPTION
skipLibCheck was enabled in earlier versions of angular. In version 15 it is no longer enabled. The OpenFin core types currently require this to be enabled. This should let you ng serve after it is built.